### PR TITLE
Remove flake8 optional dependencies in conda recipe

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -3,7 +3,7 @@
 {% set bundle = "tar.gz" %}
 {% set hash_type = "sha256" %}
 {% set hash_val = "1179f0bff86463b5308ee5f7aff1c350e1f38139d62a723e16fb2c557d1c795f" %}
-{% set build = 0 %}
+{% set build = 1 %}
 
 package:
   name: {{ name|lower }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -29,9 +29,6 @@ requirements:
   run:
     - python
     - cryptography >=1.0
-    - flake8
-    - flake8-import-order
-    - pep8-naming
 
 test:
   imports:


### PR DESCRIPTION
The following flake8 dependencies are listed as optional for [pyjwt](https://github.com/jpadilla/pyjwt/blob/master/setup.py#L74):

`flake8`
`flake8-import-order`
`pep8-naming`

This PR removes the optional flake8 dependencies from the conda recipe.